### PR TITLE
path: full -> last

### DIFF
--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -156,7 +156,7 @@ class Agent:
                     if cfg.speak_mode:
                         say_text(f"I want to execute {command_name}")
 
-                    arguments = self._resolve_pathlike_command_args(arguments)
+                    # arguments = self._resolve_pathlike_command_args(arguments)
 
                 except Exception as e:
                     logger.error("Error: \n", str(e))

--- a/autogpt/commands/audio_text.py
+++ b/autogpt/commands/audio_text.py
@@ -1,5 +1,6 @@
 """Commands for converting audio to text."""
 import json
+import os
 
 import requests
 
@@ -26,6 +27,7 @@ def read_audio_from_file(filename: str) -> str:
     Returns:
         str: The text from the audio
     """
+    filename = os.path.join(CFG.workspace_path, filename)
     with open(filename, "rb") as audio_file:
         audio = audio_file.read()
     return read_audio(audio)

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -23,6 +23,7 @@ def execute_python_file(filename: str) -> str:
     Returns:
         str: The output of the file
     """
+    filename = os.path.join(CFG.workspace_path, filename)
     logger.info(f"Executing file '{filename}'")
 
     if not filename.endswith(".py"):

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -153,6 +153,7 @@ def read_file(filename: str) -> str:
     Returns:
         str: The contents of the file
     """
+    filename = os.path.join(CFG.workspace_path, filename)
     try:
         charset_match = charset_normalizer.from_path(filename).best()
         encoding = charset_match.encoding
@@ -207,6 +208,7 @@ def write_to_file(filename: str, text: str) -> str:
     Returns:
         str: A message indicating success or failure
     """
+    filename = os.path.join(CFG.workspace_path, filename)
     checksum = text_checksum(text)
     if is_duplicate_operation("write", filename, checksum):
         return "Error: File has already been updated."
@@ -235,6 +237,7 @@ def append_to_file(filename: str, text: str, should_log: bool = True) -> str:
     Returns:
         str: A message indicating success or failure
     """
+    filename = os.path.join(CFG.workspace_path, filename)
     try:
         directory = os.path.dirname(filename)
         os.makedirs(directory, exist_ok=True)
@@ -261,6 +264,7 @@ def delete_file(filename: str) -> str:
     Returns:
         str: A message indicating success or failure
     """
+    filename = os.path.join(CFG.workspace_path, filename)
     if is_duplicate_operation("delete", filename):
         return "Error: File has already been deleted."
     try:
@@ -281,6 +285,7 @@ def list_files(directory: str) -> list[str]:
     Returns:
         list[str]: A list of files found in the directory
     """
+    directory = os.path.join(CFG.workspace_path, directory)
     found_files = []
 
     for root, _, files in os.walk(directory):
@@ -308,6 +313,7 @@ def download_file(url, filename):
         url (str): URL of the file to download
         filename (str): Filename to save the file as
     """
+    filename = os.path.join(CFG.workspace_path, filename)
     try:
         directory = os.path.dirname(filename)
         os.makedirs(directory, exist_ok=True)

--- a/autogpt/commands/git_operations.py
+++ b/autogpt/commands/git_operations.py
@@ -1,4 +1,5 @@
 """Git operations for autogpt"""
+import os
 from git.repo import Repo
 
 from autogpt.commands.command import command
@@ -26,6 +27,7 @@ def clone_repository(url: str, clone_path: str) -> str:
     Returns:
         str: The result of the clone operation.
     """
+    clone_path = os.path.join(CFG.workspace_path, clone_path)
     split_url = url.split("//")
     auth_repo_url = f"//{CFG.github_username}:{CFG.github_api_key}@".join(split_url)
     try:


### PR DESCRIPTION
원래는 agent.py에서 argument로 경로 관련이 들어가면 full path로 변환해줬는데, 이를 없애고 각 command 함수 내에서 CFG.workspace_path로 join.

장점
- autogpt 두뇌에 들어가는 토큰 수 감소하고 이해하기 더 쉬운 텍스트가 됨 (/data/project/~~~~/sokcho_restaurant.txt -> sokcho_restaurant.txt)
- argument가 filename 등 특정 패턴을 따르지 않아도 사용 가능

단점
- 커맨드 내부에서 file operation 할 때 join해줘야 함

places.py, generate_text.py 등에서도 바꿔줘야 하는데, 현재 이 외에도 수정 사항이 많아서 커밋하지 않았습니다.