### PR TITLE
translate temp 0.5 & slack app user message fix quote bug

### DIFF
--- a/autogpt/commands/generate_text.py
+++ b/autogpt/commands/generate_text.py
@@ -28,7 +28,7 @@ def truncate_text(text, max_tokens):
 
 def translate_section(section, language):
     response = create_chat_completion([{"role": "system", "content": f'Please translate markdown text to {language}. Keep special tokens intact, such as "#".'}, 
-                                       {"role": "user", "content": section}], model=CFG.fast_llm_model, temperature=0)
+                                       {"role": "user", "content": section}], model=CFG.fast_llm_model, temperature=0.5)
     return response
 
 def translate_md(md, language):

--- a/slack/app.py
+++ b/slack/app.py
@@ -93,7 +93,8 @@ api_budget: {api_budget}
 """
     else:
         user_messages = user_message.split('\n')
-        goals = [f"- {user_message}" for user_message in user_messages if user_message != ""]
+        user_messages = [user_message.replace('"', '\\"') for user_message in user_messages]
+        goals = [f'- "{user_message}"' for user_message in user_messages if user_message != ""]
         goals = '\n'.join(goals)
         ai_settings = f"""ai_name: AutoAskUp
 ai_role: an AI that achieves below GOALS.


### PR DESCRIPTION
1. translate openai temperature 0->0.5 (한글로 번역할 때 같은 단어 반복되는 현상 방지 위해)
2. slack에서 goal로 "또는 '로 시작하는 유저 메시지가 들어오면 yaml load할 때 에러 생겨서, "는 escape시키고 전체를 "~"로 감쌈